### PR TITLE
Add Visual Studio 2022 & externalconsole->console

### DIFF
--- a/fenix.json
+++ b/fenix.json
@@ -289,6 +289,88 @@
         "command": ".\\build.bat"
       },
       {
+        "id": "easycppprojects-msvc-2022-x64",
+        "displayName": "[MSVC] Windows x64, Visual Studio Build Tools 2022",
+        "description": "Create a C++ project structure for MSVC 2022 x64",
+        "language": "C++",
+        "category": [
+            "Programming"
+        ],
+        "img": "https://upload.wikimedia.org/wikipedia/commons/1/18/ISO_C%2B%2B_Logo.svg",
+        "directories": [
+            ".vscode",
+            "bin",
+            "include",
+            "lib",
+            "src"
+        ],
+        "files": {
+            "download": [
+                {
+                    "from": "cpp/main.cpp",
+                    "to": "src/main.cpp"
+                },
+                {
+                    "from": "msvc/build_x64_2022.bat",
+                    "to": "build.bat"
+                },
+                {
+                    "from": "msvc/tasks.json",
+                    "to": ".vscode/tasks.json"
+                },
+                {
+                    "from": "msvc/launch.json",
+                    "to": ".vscode/launch.json"
+                }
+            ],
+            "open": [
+                "src/main.cpp"
+            ]
+        },
+        "command": ".\\build.bat"
+      },
+      {
+        "id": "easycppprojects-msvc-2022-x86",
+        "displayName": "[MSVC] Windows x86, Visual Studio Build Tools 2022",
+        "description": "Create a C++ project structure for MSVC 2022 x86",
+        "language": "C++",
+        "category": [
+            "Programming"
+        ],
+        "img": "https://upload.wikimedia.org/wikipedia/commons/1/18/ISO_C%2B%2B_Logo.svg",
+        "directories": [
+            ".vscode",
+            "bin",
+            "include",
+            "lib",
+            "src"
+        ],
+        "files": {
+            "download": [
+                {
+                    "from": "cpp/main.cpp",
+                    "to": "src/main.cpp"
+                },
+                {
+                    "from": "msvc/build_x86_2022.bat",
+                    "to": "build.bat"
+                },
+                {
+                    "from": "msvc/tasks.json",
+                    "to": ".vscode/tasks.json"
+                },
+                {
+                    "from": "msvc/launch.json",
+                    "to": ".vscode/launch.json"
+                }
+            ],
+            "open": [
+                "src/main.cpp"
+            ]
+        },
+        "command": ".\\build.bat"
+      },
+      {
         "id": "easycppprojects-cmake",
         "displayName": "[CMake] Cross-platform (Created by KochankovID)",
         "description": "Create a C++ project structure for CMake",

--- a/msvc/build_x64_2022.bat
+++ b/msvc/build_x64_2022.bat
@@ -1,0 +1,14 @@
+@echo off
+if exist "C:\Program Files\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" (
+    call "C:\Program Files\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x64
+) else (
+    if exist "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat" (
+        call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
+    ) else (
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+    )
+)
+set compilerflags=/Od /Zi /EHsc /std:c++latest /I include
+set linkerflags=/OUT:bin\main.exe
+cl.exe %compilerflags% src\*.cpp /link %linkerflags%
+del bin\*.ilk *.obj *.pdb

--- a/msvc/build_x86_2022.bat
+++ b/msvc/build_x86_2022.bat
@@ -1,0 +1,14 @@
+@echo off
+if exist "C:\Program Files\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" (
+    call "C:\Program Files\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvarsall.bat" x86
+) else (
+    if exist "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat" (
+        call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvarsall.bat" x86
+    ) else (
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x86
+    )
+)
+set compilerflags=/Od /Zi /EHsc /std:c++latest /I include
+set linkerflags=/OUT:bin\main.exe
+cl.exe %compilerflags% src\*.cpp /link %linkerflags%
+del bin\*.ilk *.obj *.pdb

--- a/msvc/launch.json
+++ b/msvc/launch.json
@@ -11,7 +11,7 @@
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}",
             "environment": [],
-            "externalConsole": true,
+            "console": "externalTerminal"
         }
     ]
 }


### PR DESCRIPTION
Visual Studio 2022 just released these days, so I added VS2022 templates.
Also, In the task.json file in msvc folder, I changed "externalConsole": true to "console": "externalTerminal".
Because the "externalConsole" option is deprecated for launch type "cppvsdbg".